### PR TITLE
Bot can now be compiled into JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 src/commandsOld
 json/dynamic
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
             "version": "2.0.4",
             "dependencies": {
                 "@discordjs/rest": "^0.4.1",
-                "@types/node": "^17.0.33",
-                "axios": "^0.27.2",
+                "axios": "^0.26.1",
                 "canvas": "^2.9.1",
                 "chalk": "^4.1.2",
+                "cross-env": "^7.0.3",
                 "discord-api-types": "^0.30.0",
                 "discord.js": "^13.7.0",
                 "firestorm-db": "^1.10.0",
@@ -26,11 +26,13 @@
                 "tslib": "^2.4.0"
             },
             "devDependencies": {
+                "@types/node": "^17.0.33",
                 "prettier": "^2.6.2",
                 "ts-node": "^10.7.0",
                 "ts-node-dev": "^1.1.8",
                 "tsc-alias": "^1.6.7",
                 "tsconfig-paths": "^4.0.0",
+                "tslib": "^2.3.1",
                 "typescript": "^4.6.4"
             }
         },
@@ -401,12 +403,11 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "node_modules/axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
             "dependencies": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.14.8"
             }
         },
         "node_modules/balanced-match": {
@@ -578,6 +579,36 @@
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.3",
@@ -1037,6 +1068,11 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
         "node_modules/json5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -1333,6 +1369,14 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -1543,6 +1587,25 @@
             "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/signal-exit": {
@@ -1925,6 +1988,20 @@
                 "webidl-conversions": "^3.0.0"
             }
         },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/wide-align": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -2274,12 +2351,11 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
             "requires": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.14.8"
             }
         },
         "balanced-match": {
@@ -2409,6 +2485,24 @@
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
+        },
+        "cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "requires": {
+                "cross-spawn": "^7.0.1"
+            }
+        },
+        "cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            }
         },
         "debug": {
             "version": "4.3.3",
@@ -2753,6 +2847,11 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
         "json5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -2964,6 +3063,11 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
+        "path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
         "path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -3101,6 +3205,19 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
             "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+        },
+        "shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "signal-exit": {
             "version": "3.0.7",
@@ -3369,6 +3486,14 @@
             "requires": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
+            }
+        },
+        "which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "requires": {
+                "isexe": "^2.0.0"
             }
         },
         "wide-align": {

--- a/package.json
+++ b/package.json
@@ -5,22 +5,26 @@
     "main": "src/index.ts",
     "type": "commonjs",
     "scripts": {
-        "dev": "ts-node-dev --respawn -r tsconfig-paths/register src/index.ts",
+        "prettier": "prettier src/**/*.ts --config .prettierrc --write",
+        "dev": "npm run prettier && ts-node-dev --respawn -r tsconfig-paths/register src/index.ts",
         "start": "node -r ts-node/register -r tsconfig-paths/register src/index.ts",
-        "prettier": "prettier src/**/*.ts --config .prettierrc --write"
+        "start-prod": "npm run build && cross-env NODE_ENV=production node dist/src/index.js --",
+        "build": "tsc -p . && tsc-alias"
     },
     "devDependencies": {
+        "@types/node": "^17.0.33",
+        "cross-env": "^7.0.3",
         "prettier": "^2.6.2",
         "ts-node": "^10.7.0",
         "ts-node-dev": "^1.1.8",
         "tsc-alias": "^1.6.7",
         "tsconfig-paths": "^4.0.0",
+        "tslib": "^2.3.1",
         "typescript": "^4.6.4"
     },
     "dependencies": {
         "@discordjs/rest": "^0.4.1",
-        "@types/node": "^17.0.33",
-        "axios": "^0.27.2",
+        "axios": "^0.26.1",
         "canvas": "^2.9.1",
         "chalk": "^4.1.2",
         "discord-api-types": "^0.30.0",

--- a/src/client/interaction.ts
+++ b/src/client/interaction.ts
@@ -45,7 +45,7 @@ async function getString(options: TextOptions): Promise<string> {
 }
 
 async function perms(options: permissionOptions): Promise<boolean> {
-	const code = checkPermissions(this, options);
+	const code = await checkPermissions(this, options);
 	let output: string = "";
 
 	if (!code[permissionCodeEnum.users])

--- a/src/commands/bot/botban.ts
+++ b/src/commands/bot/botban.ts
@@ -50,7 +50,7 @@ export const command: SlashCommand = {
 				return;
 
 			await interaction.deferReply({ ephemeral: true });
-			const banlist = require("@json/botbans.json");
+			const banlist = await import("@json/botbans.json");
 			// const banlist = JSON.parse(banlistJSON);
 			const victimID = interaction.options.getUser("subject").id;
 			if (

--- a/src/commands/bot/changelog.ts
+++ b/src/commands/bot/changelog.ts
@@ -4,7 +4,7 @@ import { CommandInteraction, EmbedFieldData, Message } from "discord.js";
 import { Client, MessageEmbed } from "@client";
 import { readFileSync } from "fs";
 import path from "path";
-import { changelogOptions } from "index";
+import { changelogOptions } from "@/src";
 
 export const command: SlashCommand = {
 	data: new SlashCommandBuilder()
@@ -20,7 +20,10 @@ export const command: SlashCommand = {
 	execute: async (interaction: CommandInteraction, client: Client) => {
 		const versionChoice = await interaction.options.getString("version");
 
-		const changelogStr = readFileSync(path.join(__dirname, "../../../", "CHANGELOG.md"), "utf-8").replaceAll("\r", ""); //fuck caridge returns
+		const changelogStr = readFileSync(
+			path.join(__dirname, "../../../", "CHANGELOG.md").replace("dist\\", ""),
+			"utf-8",
+		).replaceAll("\r", ""); // no more \r returns
 		const allVersions = changelogStr.match(/(?<=## )([^]*?)(?=(\n## )|($))/g); //basically searches for strings between ## and another ## or the end of the file
 
 		let versions = [

--- a/src/commands/bot/eval.ts
+++ b/src/commands/bot/eval.ts
@@ -25,7 +25,7 @@ export const command: SlashCommand = {
 			return;
 		const clean = async (text: any, client: Client): Promise<string> => {
 			if (text && text.constructor.name === "Promise") text = await text;
-			if (typeof text !== "string") text = require("util").inspect(text, { depth: 1 });
+			if (typeof text !== "string") text = (await import("util")).inspect(text, { depth: 1 });
 
 			text = text
 				.replaceAll(client.tokens.token, "[BOT_TOKEN]")

--- a/src/commands/moderation/ban.ts
+++ b/src/commands/moderation/ban.ts
@@ -62,7 +62,7 @@ export const command: SlashCommand = {
 				{ name: "Reason", value: reason ? reason : "No reason given.", inline: true },
 			]);
 
-		await interaction.reply({content: "\u200B"})
+		await interaction.reply({ content: "\u200B" });
 		await interaction.deleteReply();
 		const message: Message = (await interaction.channel.send({ embeds: [embed] })) as any;
 

--- a/src/commands/moderation/kick.ts
+++ b/src/commands/moderation/kick.ts
@@ -62,7 +62,7 @@ export const command: SlashCommand = {
 				{ name: "Reason", value: reason ? reason : "No reason given.", inline: true },
 			]);
 
-		await interaction.reply({content: "\u200B"})
+		await interaction.reply({ content: "\u200B" });
 		await interaction.deleteReply();
 		const message: Message = (await interaction.channel.send({ embeds: [embed] })) as any;
 

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -71,7 +71,7 @@ export const command: SlashCommand = {
 				{ name: "Timeout", value: `<t:${(new Date().getTime() / 1000 + timeout).toFixed(0)}:R>`, inline: true },
 			]);
 
-		await interaction.reply({content: "\u200B"})
+		await interaction.reply({ content: "\u200B" });
 		await interaction.deleteReply();
 		const message: Message = (await interaction.channel.send({ embeds: [embed] })) as any;
 

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -7,7 +7,7 @@ export const event: Event = {
 	run: async (client: Client, interaction: Interaction) => {
 		if (!interaction.inGuild()) return;
 
-		const banlist = require("@json/botbans.json");
+		const banlist = await import("@json/botbans.json");
 		if (banlist.ids.indexOf(interaction.user.id) > -1) {
 			(interaction as CommandInteraction | ButtonInteraction | SelectMenuInteraction).reply({
 				content: await (

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -18,7 +18,10 @@ export const event: Event = {
 
 		if (message.author && message.author.bot) return;
 
-		if ((client.tokens.dev || getTeamsIds({ name: "faithful" }).includes(message.guild.id)) && !getSubmissionsChannels(client).includes(message.channelId)) {
+		if (
+			(client.tokens.dev || getTeamsIds({ name: "faithful" }).includes(message.guild.id)) &&
+			!getSubmissionsChannels(client).includes(message.channelId)
+		) {
 			const embed = new MessageEmbed()
 				.setAuthor({ name: `${message.author.tag} deleted a message` })
 				.setColor(colors.red)
@@ -26,14 +29,14 @@ export const event: Event = {
 				.addFields([
 					{ name: "Server", value: message.guild.name, inline: true },
 					{ name: "Channel", value: `<#${message.channel.id}>`, inline: true },
-					{ name: "Message Content", value: `\`\`\`${message.content.replaceAll("```", "'''")}\`\`\`` }
+					{ name: "Message Content", value: `\`\`\`${message.content.replaceAll("```", "'''")}\`\`\`` },
 				])
 				.setDescription(`[Jump to location](${message.url})\n`)
 				.setTimestamp();
 
-			const logChannelId = client.tokens.dev 
-				? client.config.discords.filter(d => d.name === "dev")[0].channels.moderation
-				: client.config.teams.filter(t => t.name === "faithful")[0].channels.logs;
+			const logChannelId = client.tokens.dev
+				? client.config.discords.filter((d) => d.name === "dev")[0].channels.moderation
+				: client.config.teams.filter((t) => t.name === "faithful")[0].channels.logs;
 
 			const logChannel = client.channels.cache.get(logChannelId) as TextChannel;
 			await logChannel.send({ embeds: [embed] });

--- a/src/helpers/functions/errorHandler.ts
+++ b/src/helpers/functions/errorHandler.ts
@@ -1,8 +1,4 @@
-import {
-	MessageAttachment,
-	MessageEmbed,
-	TextChannel,
-} from "discord.js";
+import { MessageAttachment, MessageEmbed, TextChannel } from "discord.js";
 import { Client } from "@client";
 import fs from "fs";
 import { err } from "@helpers/logger";
@@ -51,7 +47,9 @@ export const logConstructor: Function = (
 	client: Client,
 	reason: any = { stack: "You requested it with /logs ¯\\_(ツ)_/¯" },
 ): MessageAttachment => {
-	const logTemplate = fs.readFileSync(path.join(__dirname + "/errorHandler.log"), { encoding: "utf-8" });
+	const logTemplate = fs.readFileSync(path.join(__dirname + "/errorHandler.log").replace("dist\\", ""), {
+		encoding: "utf-8",
+	});
 	const template = logTemplate.match(new RegExp(/\%templateStart%([\s\S]*?)%templateEnd/))[1]; // get message template
 
 	const t = Math.floor(Math.random() * randomSentences.length);
@@ -80,7 +78,7 @@ export const logConstructor: Function = (
 						  }`
 						: log.type === "message"
 						? `${log.type} [${log.data.isDeleted ? "deleted" : "created"}] | ${
-							log.data.author ? (log.data.author.bot ? "BOT" : "USER") : "Unknown (likely bot)"
+								log.data.author ? (log.data.author.bot ? "BOT" : "USER") : "Unknown (likely bot)"
 						  } | ${log.data.author ? log.data.author.username : "Unknown"}`
 						: log.type,
 				)

--- a/src/helpers/locales/string.ts
+++ b/src/helpers/locales/string.ts
@@ -1,4 +1,5 @@
 import { ids, parseId } from "@helpers/emojis";
+import path from "path";
 import { langs, en_US, JSONFiles } from ".";
 export type keys = keyof typeof en_US;
 
@@ -8,14 +9,15 @@ export interface Placeholder {
 
 export async function string(country_code: langs, key: keys, placeholders?: Placeholder): Promise<string> {
 	let lang: {};
-	for (let i = 0; JSONFiles[i]; i++) lang = { ...lang, ...(await import(`@/lang/en-US/${JSONFiles[i]}.json`)) }; // fallback
+	for (let i = 0; JSONFiles[i]; i++)
+		lang = { ...lang, ...(await import(path.join(__dirname, "../../../", `/lang/en-US/${JSONFiles[i]}.json`))) }; // fallback
 
 	if (country_code !== "en-GB" && country_code !== "en-US")
 		// because the fallback is already IN ENGLISH
 		for (let i = 0; JSONFiles[i]; i++)
 			try {
 				//* We try the import before spreading the object to avoid issues, we only want to check if the file exists
-				const lang2 = await import(`@/lang/${country_code}/${JSONFiles[i]}.json`);
+				const lang2 = await import(path.join(__dirname, "../../../", `/lang/${country_code}/${JSONFiles[i]}.json`));
 				lang = { ...lang, ...lang2 };
 			} catch {} // file not found
 

--- a/src/helpers/permissions v2/slashCommandPermissions.ts
+++ b/src/helpers/permissions v2/slashCommandPermissions.ts
@@ -52,7 +52,10 @@ type permissionCode = [boolean, boolean, boolean];
  */
 
 //TODO: use a bearer token for v2 in the future. This is a temporary workaround
-export function checkPermissions(interaction: CommandInteraction, permissions: permissionOptions): permissionCode {
+export async function checkPermissions(
+	interaction: CommandInteraction,
+	permissions: permissionOptions,
+): Promise<permissionCode> {
 	let code: permissionCode = [true, true, true];
 
 	let type = permissions.type ? permissions.type : "config";
@@ -95,7 +98,7 @@ export function checkPermissions(interaction: CommandInteraction, permissions: p
 	}
 
 	if (type == "config") {
-		const config = require("@json/config.json");
+		const config = await import("@json/config.json");
 
 		if (permissions.roles) {
 			const roles = (interaction.member.roles as GuildMemberRoleManager).cache.map((r) => r.id);

--- a/src/helpers/teams.ts
+++ b/src/helpers/teams.ts
@@ -8,17 +8,17 @@ const config: Config = configJson;
  * @param {string|string[]} options.name - team name (or names) you want ids
  * @returns {string[]} - ids you searched
  */
-export const getTeamsIds = (options: {
-    name: string | Array<string>;
-}): Array<string> => {
-    const output: Array<string> = [];
+export const getTeamsIds = (options: { name: string | Array<string> }): Array<string> => {
+	const output: Array<string> = [];
 
-    const search = (name: string): void => { 
-        output.push(...config.discords.filter((discord) => discord.team !== undefined && discord.team !== name).map((d) => d.team))
-    };
+	const search = (name: string): void => {
+		output.push(
+			...config.discords.filter((discord) => discord.team !== undefined && discord.team !== name).map((d) => d.team),
+		);
+	};
 
-    if (typeof options.name === "string") search(options.name);
-    else options.name.forEach((name) => search(name));
+	if (typeof options.name === "string") search(options.name);
+	else options.name.forEach((name) => search(name));
 
-    return output;
-}
+	return output;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,10 @@ import path from "path";
 
 //this is my 13th reason why
 export let changelogOptions = () => {
-	const changelogStr = readFileSync(path.join(__dirname, "../", "CHANGELOG.md"), "utf-8").replaceAll("\r", "");
+	const changelogStr = readFileSync(
+		path.join(__dirname, "../", "CHANGELOG.md").replace("dist\\", ""),
+		"utf-8",
+	).replaceAll("\r", "");
 	const allVersions = changelogStr.match(/(?<=## )([^]*?)(?=(\n## )|($))/g);
 
 	let versions = [

--- a/src/menus/submission/submitTextureSelect.ts
+++ b/src/menus/submission/submitTextureSelect.ts
@@ -3,7 +3,7 @@ import { zipToMA } from "@functions/zipToMessageAttachments";
 import { info } from "@helpers/logger";
 import { SelectMenu } from "@interfaces";
 import { MessageAttachment } from "discord.js";
-import { processFiles } from "events/textureSubmitted";
+import { processFiles } from "@/src/events/textureSubmitted";
 
 export const menu: SelectMenu = {
 	selectMenuId: "submitTextureSelect",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,14 +21,14 @@
 		"baseUrl": "src",
 		"paths": {
 			"@/*": ["../*"],
-			"@client": ["client"],
-			"@client/buttons/*": ["buttons/*"],
-			"@client/commands/*": ["commands/*"],
-			"@client/menus/*": ["menus/*"],
-			"@functions/*": ["helpers/functions/*"],
-			"@class/*": ["helpers/class/*"],
-			"@helpers/*": ["helpers/*"],
-			"@interfaces": ["helpers/interfaces"],
+			"@client": ["../src/client"],
+			"@client/buttons/*": ["../src/buttons/*"],
+			"@client/commands/*": ["../src/commands/*"],
+			"@client/menus/*": ["../src/menus/*"],
+			"@functions/*": ["../src/helpers/functions/*"],
+			"@class/*": ["../src/helpers/class/*"],
+			"@helpers/*": ["../src/helpers/*"],
+			"@interfaces": ["../src/helpers/interfaces"],
 			"@json/*": ["../json/*"]
 		}
 	},


### PR DESCRIPTION
We are currently using node-ts in production with auto-restart on file change; 
> (Which is one of the worst things to do)

So I've wrapped up some code & google searchs to make this possible;
To run the bot on compiled JS:

```bash
npm run start-prod
```

## Changes
- Be careful now when you're looking for `.ts` files, they don't exist on prod
- Be also careful about the path above the `src` folder, they don't have to contain `dist` or the bot won't find the files.
- `npm run prettier` is automatically run when doing `npm run dev` (this would avoid special commit with 2349 files changes)

> @nick-1666 stop using `require()` with alias path (the one starting with an `@`), `tsc` (the compiler) doesn't translate them :/

Please launch the bot on your machine & test it I did not take the time to check **_everything_**.