### PR TITLE
Possible instapass rewrite and fix.

### DIFF
--- a/commands/Compliance/autopush.js
+++ b/commands/Compliance/autopush.js
@@ -22,8 +22,8 @@ module.exports = {
 		if (!args.length) return warnUser(message, strings.command.args.invalid.generic)
 
 		if (args[0] == 'all') {
-			for (let packName in settings.submission) {
-				await downloadResults(client, settings.submission[packName].channels.results)
+			for (let pack of Object.values(settings.submission)) {
+				await downloadResults(client, pack.channels.results)
 			}
 		}
 

--- a/events/ready.js
+++ b/events/ready.js
@@ -24,26 +24,28 @@ const { doCheckSettings } = require('../functions/settings/doCheckSettings')
  * - Push to GitHub process (each day at 00:15 GMT) : @function pushToGithub
  */
 const submissionProcess = new cron.CronJob('0 0 * * *', async () => {
-  for (let packName in settings.submission) {
+  for (let pack of Object.values(settings.submission)) {
     await retrieveSubmission (
       client,
-      settings.submission[packName].channels.submit,
-      settings.submission[packName].channels.council,
-      settings.submission[packName].vote_time
+      pack.channels.submit,
+      pack.channels.council,
+      pack.channels.results,
+      pack.vote_time
     )
+
     await councilSubmission (
       client,
-      settings.submission[packName].channels.council,
-      settings.submission[packName].channels.results,
-      settings.submission[packName].council_time
+      pack.channels.council,
+      pack.channels.results,
+      pack.council_time
     )
   }
 })
 const downloadToBot = new cron.CronJob('15 0 * * *', async () => {
-  for (let packName in settings.submission) {
+  for (let pack of Object.values(settings.submission)) {
     await downloadResults (
       client,
-      settings.submission[packName].channels.results
+      pack.channels.results
     )
   }
 })

--- a/functions/textures/admission/downloadResults.js
+++ b/functions/textures/admission/downloadResults.js
@@ -17,12 +17,12 @@ var Buffer = require('buffer/').Buffer
  * @param {String} channelInID discord text channel from where the bot should download texture
  */
 async function downloadResults(client, channelInID) {
-	let messages = await getMessages(client, channelInID)
-
+	let messages = await getMessages(client, channelInID);
 	let repoKey; // declared outside loop so there's no scope issues
-	for (let repoName in settings.submission) { // since the key is used too for-in is necessary
-		if (settings.submission[repoName].channels.results == channelInID) {
-		    repoKey = repoName;
+
+	for (let [packKey, packValue] of Object.entries(settings.submission)) {
+		if (packValue.channels.results == channelInID) {
+		    repoKey = packKey;
 		    break;
 		}
 	}
@@ -87,7 +87,7 @@ async function downloadResults(client, channelInID) {
 		const response = await fetch(textureURL)
 		const buffer = await response.arrayBuffer()
 
-		// download the texture to all it's paths
+		// download the texture to all its paths
 		for (let j = 0; allPaths[j]; j++) {
 			// create full folder path
 			await fs.promises.mkdir(allPaths[j].substr(0, allPaths[j].lastIndexOf('/')), { recursive: true })
@@ -100,7 +100,7 @@ async function downloadResults(client, channelInID) {
 			})
 		}
 
-		// prepare the authors for the texture:
+		// prepare the authors for the texture
 		allContribution.push({
 			date: textureDate,
 			resolution: res,

--- a/functions/textures/admission/downloadResults.js
+++ b/functions/textures/admission/downloadResults.js
@@ -20,7 +20,7 @@ async function downloadResults(client, channelInID) {
 	let messages = await getMessages(client, channelInID)
 
 	let repoKey; // declared outside loop so there's no scope issues
-	for (let repoName in settings.submission) {
+	for (let repoName in settings.submission) { // since the key is used too for-in is necessary
 		if (settings.submission[repoName].channels.results == channelInID) {
 		    repoKey = repoName;
 		    break;

--- a/functions/textures/submission/councilSubmission.js
+++ b/functions/textures/submission/councilSubmission.js
@@ -39,7 +39,7 @@ async function councilSubmission(client, channelFromID, channelResultsID, delay)
     return message
   })
 
-  // split messages following their up/down votes (upvote > downvote)
+  // split messages following their up/down votes (upvote >= downvote)
   let messagesUpvoted = messages.filter(message => message.upvote >= message.downvote)
   let messagesDownvoted = messages.filter(message => message.upvote < message.downvote)
 
@@ -57,7 +57,7 @@ async function councilSubmission(client, channelFromID, channelResultsID, delay)
     editEmbed(message.message, `<:upvote:${settings.emojis.upvote}> Sent to results!`)
   })
 
-  // send upvoted messages to #results (denied)
+  // send downvoted messages to #results (denied)
   messagesDownvoted.forEach(message => {
     let embed = message.embed
     embed.setColor(settings.colors.red)

--- a/functions/textures/submission/editSubmission.js
+++ b/functions/textures/submission/editSubmission.js
@@ -85,7 +85,6 @@ async function editSubmission(client, reaction, user) {
         if (REACTION.emoji.id === settings.emojis.instapass && member.roles.cache.some(role => role.name.toLowerCase().includes("council") || role.name.toLowerCase().includes("admin") )) {
           removeReact(message, [settings.emojis.upvote, settings.emojis.downvote])
           changeStatus(message, `<:instapass:${settings.emojis.instapass}> Instapassed`)
-          instapass(client, message)
         }
         if (REACTION.emoji.id === settings.emojis.invalid && member.roles.cache.some(role => role.name.toLowerCase().includes("council") || role.name.toLowerCase().includes("admin"))) {
           removeReact(message, [settings.emojis.upvote, settings.emojis.downvote])
@@ -108,55 +107,6 @@ async function editSubmission(client, reaction, user) {
         console.log(err)
       })
   }
-
-}
-
-async function instapass(client, message) {
-  let channelOut;
-  let channelArray;
-
-  for (let packName in settings.submission) { // need a for loop here to get the pack name properly
-    channelArray = Object.values(settings.submission[packName].channels);
-    if (channelArray.includes(message.channel.id)) { // picks up both submit and council
-      channelOut = await client.channels.fetch(settings.submission[packName].channels.results);
-      break;
-    }
-  }
-
-  if (!channelOut) {
-    warnUser(message, "Result channel was not able to be fetched.");
-    return;
-  }
-
-  channelOut.send({
-    embeds:
-      [message.embeds[0]
-        .setColor(settings.colors.green)
-        .setDescription(`[Original Post](${message.url})\n${message.embeds[0].description ? message.embeds[0].description : ''}`)
-      ]
-  })
-    .then(async sentMessage => {
-      for (const emojiID of [settings.emojis.see_more]) await sentMessage.react(client.emojis.cache.get(emojiID))
-    })
-
-  editEmbed(message)
-}
-
-async function editEmbed(message) {
-  let embed = message.embeds[0]
-  // fix the weird bug that also apply changes to the old embed (wtf)
-  const submissionChannels = Object.values(settings.submission).map(i => i.channels.submit);
-  const councilChannels = Object.values(settings.submission).map(i => i.channels.council);
-
-  if (submissionChannels.includes(message.channel.id))
-    embed.setColor(settings.colors.blue)
-
-  else if (councilChannels.includes(message.channel.id))
-    embed.setColor(settings.colors.council)
-
-  if (embed.description !== null) embed.setDescription(message.embeds[0].description.replace(`[Original Post](${message.url})\n`, ''))
-
-  await message.edit({ embeds: [embed] })
 }
 
 async function changeStatus(message, string) {

--- a/functions/textures/submission/retrieveSubmission.js
+++ b/functions/textures/submission/retrieveSubmission.js
@@ -23,7 +23,7 @@ async function retrieveSubmission(client, channelFromID, channelOutID, channelIn
 		let messageDate = new Date(message.createdTimestamp);
 		return messageDate.getDate() == instapassedDate.getDate() && messageDate.getMonth() == instapassedDate.getMonth();
 	}) // only get instapassed textures
-		.filter(message => message.embed.length > 0)
+		.filter(message => message.embeds.length > 0)
 		.filter(message => message.embeds[0].fields[1] !== undefined && (message.embeds[0].fields[1].value.includes(settings.emojis.instapass)))
 
 

--- a/functions/textures/submission/retrieveSubmission.js
+++ b/functions/textures/submission/retrieveSubmission.js
@@ -13,6 +13,7 @@ const { getMessages } = require('../../../helpers/getMessages')
 async function retrieveSubmission(client, channelFromID, channelOutID, channelInstapassID, delay) {
 	let messages = await getMessages(client, channelFromID)
 	let channelOut = client.channels.cache.get(channelOutID)
+	let channelInstapass = client.channels.cache.get(channelInstapassID)
 
 	let delayedDate = new Date();
 	delayedDate.setDate(delayedDate.getDate() - delay);
@@ -73,7 +74,7 @@ async function retrieveSubmission(client, channelFromID, channelOutID, channelIn
 		embed.setColor(settings.colors.green);
 		embed.fields[1].value = `<:instapass:${settings.emojis.instapass}> Instapassed`;
 
-		channelInstapassID.send({ embeds: [embed] })
+		channelInstapass.send({ embeds: [embed] })
 			.then(async sentMessage => {
 				for (const emojiID of [settings.emojis.see_more]) await sentMessage.react(client.emojis.cache.get(emojiID))
 			})

--- a/functions/textures/submission/retrieveSubmission.js
+++ b/functions/textures/submission/retrieveSubmission.js
@@ -16,8 +16,7 @@ async function retrieveSubmission(client, channelFromID, channelOutID, channelIn
 	let delayedDate = new Date();
 	delayedDate.setDate(delayedDate.getDate() - delay);
 
-	let instapassedDate = new Date();
-	instapassedDate.setDate(instapassedDate.getDate); // no delay
+	let instapassedDate = new Date(); // no delay
 
 	let messagesInstapassed = messages.filter(message => {
 		let messageDate = new Date(message.createdTimestamp);

--- a/functions/textures/submission/retrieveSubmission.js
+++ b/functions/textures/submission/retrieveSubmission.js
@@ -13,30 +13,32 @@ async function retrieveSubmission(client, channelFromID, channelOutID, channelIn
 	let messages = await getMessages(client, channelFromID)
 	let channelOut = client.channels.cache.get(channelOutID)
 
-	let delayedDate = new Date()
-	delayedDate.setDate(delayedDate.getDate() - delay)
+	let delayedDate = new Date();
+	delayedDate.setDate(delayedDate.getDate() - delay);
+
+	let instapassedDate = new Date();
+	instapassedDate.setDate(instapassedDate.getDate); // no delay
+
+	let messagesInstapassed = messages.filter(message => {
+		let messageDate = new Date(message.createdTimestamp);
+		return messageDate.getDate() == instapassedDate.getDate() && messageDate.getMonth() == instapassedDate.getMonth();
+	}) // only get instapassed textures
+		.filter(message => message.embed.length > 0)
+		.filter(message => message.embeds[0].fields[1] !== undefined && (message.embeds[0].fields[1].value.includes(settings.emojis.instapass)))
+
 
 	// filter message in the right timezone
 	messages = messages.filter(message => {
 		let messageDate = new Date(message.createdTimestamp)
-		return messageDate.getDate() == delayedDate.getDate() && messageDate.getMonth() == delayedDate.getMonth()
-	})
-
-	// filter message that only have embeds & that have a pending status
-
-	messagesInstapassed = messages
-		.filter(message => message.embed.length > 0)
-		.filter(message => message.embeds[0].fields[1] !== undefined && (message.embeds[0].fields[1].value.includes(settings.emojis.instapass)))
-
-	messages = messages
+		return messageDate.getDate() == delayedDate.getDate() && messageDate.getMonth() == delayedDate.getMonth();
+	}) // only get pending submissions
 		.filter(message => message.embeds.length > 0)
 		.filter(message => message.embeds[0].fields[1] !== undefined && (message.embeds[0].fields[1].value.includes('⏳') || message.embeds[0].fields[1].value.includes(settings.emojis.pending)))
 
 	// map messages adding reacts count, embed and message (easier management like that)
 	messages = messages.map(message => {
-
-		let upvotes
-		let downvotes
+		let upvotes;
+		let downvotes;
 
 		if (message.reactions.cache.get(settings.emojis.upvote_old)) {
 			upvotes = message.reactions.cache.get(settings.emojis.upvote_old).count
@@ -54,7 +56,7 @@ async function retrieveSubmission(client, channelFromID, channelOutID, channelIn
 			message: message
 		}
 
-		return message
+		return message;
 	})
 
 	// split messages following their up/down votes (upvote >= downvote)

--- a/functions/textures/submission/retrieveSubmission.js
+++ b/functions/textures/submission/retrieveSubmission.js
@@ -7,6 +7,7 @@ const { getMessages } = require('../../../helpers/getMessages')
  * @param {DiscordClient} client
  * @param {String} channelFromID text-channel from where submission are retrieved
  * @param {String} channelOutID text-channel where submission are sent
+ * @param {String} channelInstapassID text-channel where instapassed textures are sent
  * @param {Integer} delay delay in day from today
  */
 async function retrieveSubmission(client, channelFromID, channelOutID, channelInstapassID, delay) {


### PR DESCRIPTION
The problem with the current instapass system is likely in the way results are downloaded and fetched. For each day, the bot only downloads the textures posted to #results on that exact day. This seems fine until you think about the fact that instapassed textures are technically pushed the day before, since the timer is based off Central European time where it's midnight and therefore counts as a "new day". 

This means that instapassed embeds are consistently a day behind in being pushed and therefore do not work — the code is doing exactly what was intended so no errors were ever logged. While a potential solution was made well over a year ago by Robert at https://github.com/Faithful-Resource-Pack/Discord-Bot/commit/6f35be291daf93de898d69c64254a34a19cf3564, it was a messy solution. Trying to grab all textures from a given range that isn't a full day had a lot of issuess with conversion, so the fix got reverted soon after.

I've decided to solve the problem by pushing instapassed textures synchronously with all other textures for the day rather than on their own — this should solve all the time and date issues without needing large libraries to ensure nothing gets skipped.

ACTUAL CHANGES:

- Synchronized pushing of instapassed textures with all other textures for the day.
- Added an instapass result channel field to the `retrieveSubmissions()` function which is called for each pack at midnight Central European time.
- Removed all legacy instapass code since none of it really worked:
   - The only parts left from the original are the code that edits the embed, since this is used in the new code to filter out instapassed textures from the rest.
   - All the rest of the logic is handled in the `retrieveSubmissions()` function instead of in `editSubmission()`.
- Clean up a few other things I noticed such as a lot of duplicate code and some inaccurate comments.

None of this has been tested yet which is why I'm not committing this directly. Most of the new instapass code is directly referenced from the council retrieval code since it uses a similar elimination process, so there shouldn't be any issues, but it's JavaScript so who knows honestly.