### PR TITLE
Improve /guidelines command.

### DIFF
--- a/json/guidelines.json
+++ b/json/guidelines.json
@@ -1,0 +1,19 @@
+{
+    "choices": [
+        {
+            "names": ["color blending", "blending"],
+            "faithful_32x": "blending",
+            "classic_faithful_32x": "blending"
+        },
+        {
+            "names": ["no blending", "simple shading"],
+            "faithful_32x": "no-blending",
+            "classic_faithful_32x": "no-blending"
+        },
+        {
+            "names": ["aa", "antialiasing", "anti aliasing", "anti-aliasing"],
+            "faithful_32x": "anti-aliasing",
+            "classic_faithful_32x": "antialiasing"
+        }
+    ]
+}

--- a/json/guidelines.json
+++ b/json/guidelines.json
@@ -80,6 +80,135 @@
         {
             "keywords": ["stairing", "staired pixels"],
             "classic_faithful_32x": "stairing"
+        },
+        {
+            "keywords": ["conventional upscaling", "normal upscaling", "painted upscaling", "conventional", "normal", "painted"],
+            "classic_faithful_32x": "conventional"
+        },
+        {
+            "keywords": ["smooth metal", "polished metal"],
+            "faithful_32x": "smooth-metal",
+            "classic_faithful_32x": "gem-and-metals"
+        },
+        {
+            "keywords": ["rough metal", "raw metal", "unpolished metal"],
+            "faithful_32x": "rough-metal"
+        },
+        {
+            "keywords": ["gemstones", "gems"],
+            "faithful_32x": "gems",
+            "classic_faithful_32x": "gems-and-metals"
+        },
+        {
+            "keywords": ["contiguous stones", "smooth stone"],
+            "faithful_32x": "contiguous-stones",
+            "classic_faithful_32x": "contiguous-stones"
+        },
+        {
+            "keywords": ["polished stone", "polished stones"],
+            "faithful_32x": "polished-stone",
+            "classic_faithful_32x": "polished-stone"
+        },
+        {
+            "keywords": ["rocky materials", "rocky", "rock", "distinct stones"],
+            "faithful_32x": "rocky-materials",
+            "classic_faithful_32x": "distinct-stones"
+        },
+        {
+            "keywords": ["large bricks", "stone bricks", "bricks"],
+            "classic_faithful_32x": "large-bricks"
+        },
+        {
+            "keywords": ["tiles", "small bricks"],
+            "classic_faithful_32x": "tiles"
+        },
+        {
+            "keywords": ["bark", "stems", "logs"],
+            "faithful_32x": "wood",
+            "classic_faithful_32x": "logs-and-stems"
+        },
+        {
+            "keywords": ["refined wood", "planks", "wood"],
+            "faithful_32x": "wood",
+            "classic_faithful_32x": "refined-wood"
+        },
+        {
+            "keywords": ["flowers", "foliage", "plant matter", "bushes"],
+            "faithful_32x": "flowers",
+            "classic_faithful_32x": "foliage"
+        },
+        {
+            "keywords": ["leaves", "large plants"],
+            "faithful_32x": "flowers",
+            "classic_faithful_32x": "large-plants"
+        },
+        {
+            "keywords": ["grass", "fungi"],
+            "classic_faithful_32x": "grass-fungi"
+        },
+        {
+            "keywords": ["corals"],
+            "faithful_32x": "corals"
+        },
+        {
+            "keywords": ["sand", "powder"],
+            "faithful_32x": "sands",
+            "classic_faithful_32x": "sand"
+        },
+        {
+            "keywords": ["sandstone", "slate"],
+            "classic_faithful_32x": "sandstone"
+        },
+        {
+            "keywords": ["prismarine"],
+            "classic_faithful_32x": "prismarine"
+        },
+        {
+            "keywords": ["bee nest", "beehive"],
+            "faithful_32x": "bee-nests"
+        },
+        {
+            "keywords": ["honey", "slime"],
+            "faithful_32x": "honey"
+        },
+        {
+            "keywords": ["glazed terracotta", "glaze", "terracotta"],
+            "faithful_32x": "terracotta"
+        },
+        {
+            "keywords": ["glass", "ice"],
+            "faithful_32x": "glass",
+            "classic_faithful_32x": "ice-glass"
+        },
+        {
+            "keywords": ["bone", "bones"],
+            "faithful_32x": "bones"
+        },
+        {
+            "keywords": ["cloth", "paper", "fabric", "fur"],
+            "faithful_32x": "cloth-paper",
+            "classic_faithful_32x": "fur-fabric"
+        },
+        {
+            "keywords": ["skin"],
+            "faithful_32x": "skin",
+            "classic_faithful_32x": "fur-fabric"
+        },
+        {
+            "keywords": ["doors", "trapdoors"],
+            "classic_faithful_32x": "door-trapdoor"
+        },
+        {
+            "keywords": ["creeper", "creepers"],
+            "faithful_32x": "creepers"
+        },
+        {
+            "keywords": ["fish", "fish entity"],
+            "faithful_32x": "fish"
+        },
+        {
+            "keywords": ["cylinder", "cylinder shading"],
+            "faithful_32x": "cylinders"
         }
     ]
 }

--- a/json/guidelines.json
+++ b/json/guidelines.json
@@ -1,19 +1,85 @@
 {
     "choices": [
         {
-            "names": ["color blending", "blending"],
+            "keywords": ["color blending", "blending"],
             "faithful_32x": "blending",
             "classic_faithful_32x": "blending"
         },
         {
-            "names": ["no blending", "simple shading"],
+            "keywords": ["no blending", "simple shading"],
             "faithful_32x": "no-blending",
             "classic_faithful_32x": "no-blending"
         },
         {
-            "names": ["aa", "antialiasing", "anti aliasing", "anti-aliasing"],
+            "keywords": ["aa", "antialiasing", "anti aliasing", "anti-aliasing"],
             "faithful_32x": "anti-aliasing",
             "classic_faithful_32x": "antialiasing"
+        },
+        {
+            "keywords": ["dithering", "dither"],
+            "faithful_32x": "dithering",
+            "classic_faithful_32x": "dithering"
+        },
+        {
+            "keywords": ["color banding", "banding", "colour banding"],
+            "faithful_32x": "colour-banding",
+            "classic_faithful_32x": "color-banding"
+        },
+        {
+            "keywords": ["upscaling", "nearest neighbor", "nearest neighbour", "upscale"],
+            "faithful_32x": "upscaling-a-texture",
+            "classic_faithful_32x": "upscaling-textures"
+        },
+        {
+            "keywords": ["indexing", "limited palette", "limited palettes", "quantizing"],
+            "faithful_32x": "indexing-colours",
+            "classic_faithful_32x": "limited-palettes"
+        },
+        {
+            "keywords": ["noise"],
+            "classic_faithful_32x": "noise"
+        },
+        {
+            "keywords": ["jappa", "jasper", "jasper boerstra"],
+            "faithful_32x": "jappa",
+            "classic_faithful_32x": "jappa"
+        },
+        {
+            "keywords": ["programmer art", "pa", "progart", "prog art"],
+            "faithful_32x": "prog-art",
+            "classic_faithful_32x": "prog-art"
+        },
+        {
+            "keywords": ["jappa textures", "jappa art"],
+            "faithful_32x": "jappa-textures",
+            "classic_faithful_32x": "jappa-textures"
+        },
+        {
+            "keywords": ["vattic", "founder", "creator"],
+            "classic_faithful_32x": "vattic"
+        },
+        {
+            "keywords": ["false lines", "phantom lines"],
+            "faithful_32x": "false-lines",
+            "classic_faithful_32x": "false-lines"
+        },
+        {
+            "keywords": ["mixels", "mixed pixels"],
+            "faithful_32x": "mixels",
+            "classic_faithful_32x": "mixels"
+        },
+        {
+            "keywords": ["color contrast", "contrast", "contrasty", "colour contrast"],
+            "faithful_32x": "contrast-palette",
+            "classic_faithful_32x": "contrast"
+        },
+        {
+            "keywords": ["depth shading", "polished shading"],
+            "classic_faithful_32x": "depth-shading"
+        },
+        {
+            "keywords": ["stairing", "staired pixels"],
+            "classic_faithful_32x": "stairing"
         }
     ]
 }

--- a/src/commands/faithful/guidelines.ts
+++ b/src/commands/faithful/guidelines.ts
@@ -46,16 +46,14 @@ export const command: SlashCommand = {
 		if (choice) {
 			choice = choice.toLowerCase(); // remove case sensitivity for easier parsing
 			if (!guidelineJSON.choices.map(i => i.keywords).flat().includes(choice)) { // if it's not present anywhere escape early
-				contents = ""
-				interaction.reply({ embeds: [errorEmbed], ephemeral: true })
+				interaction.reply({ embeds: [errorEmbed], ephemeral: true });
 				return;
 			}
 
 			for (let i of guidelineJSON.choices) {
 				if (!i.keywords.includes(choice)) continue;
 				if (!i[pack]) { // if you pick an option that isn't present in the pack you selected
-					contents = ""
-					interaction.reply({ embeds: [errorEmbed], ephemeral: true })
+					interaction.reply({ embeds: [errorEmbed], ephemeral: true });
 					return;
 				}
 				contents += `#${i[pack]}`; // adds the html id specified in the json

--- a/src/commands/faithful/guidelines.ts
+++ b/src/commands/faithful/guidelines.ts
@@ -27,11 +27,11 @@ export const command: SlashCommand = {
 		),
 	execute: async (interaction: CommandInteraction) => {
 		let contents: string;
+		let choice = interaction.options.getString("choice");
 		const pack = interaction.options.getString("pack");
-		const choice = interaction.options.getString("choice");
 		const errorEmbed = new MessageEmbed()
 			.setTitle("Invalid choice!")
-			.setDescription(`\`${choice}\` is not a valid choice.`)
+			.setDescription(`\`${choice}\` is not a valid choice. Have you chosen the wrong pack or made a typo?`)
 			.setColor(colors.red);
 
 		switch (pack) {
@@ -43,19 +43,22 @@ export const command: SlashCommand = {
 				break;
 		}
 
-		if (choice) { // if someone just called the entire guidelines
-			if (!guidelineJSON.choices.map(i => i.names).flat().includes(choice)) {
+		if (choice) {
+			choice = choice.toLowerCase(); // remove case sensitivity for easier parsing
+			if (!guidelineJSON.choices.map(i => i.keywords).flat().includes(choice)) { // if it's not present anywhere escape early
 				contents = ""
 				interaction.reply({ embeds: [errorEmbed], ephemeral: true })
 				return;
 			}
 
 			for (let i of guidelineJSON.choices) {
-				if (!i.names.includes(choice)) continue;
-				if (!i[pack]) {
+				if (!i.keywords.includes(choice)) continue;
+				if (!i[pack]) { // if you pick an option that isn't present in the pack you selected
+					contents = ""
 					interaction.reply({ embeds: [errorEmbed], ephemeral: true })
+					return;
 				}
-				contents += `#${i[pack]}`;
+				contents += `#${i[pack]}`; // adds the html id specified in the json
 				break;
 			}
 		}


### PR DESCRIPTION
The current /guidelines command is really lackluster currently imo. It lets you access the guideline URLs and that's about it.

I've decided to improve the command by creating a JSON of mappings for each definition and material, and allowing you to specify a third, optional, argument where you can select a specific part of the guidelines to link to. This makes it easier for people to show novice artists a certain definition without having to go to the guidelines and paste the url in, and has no real downsides.

Since the classic faithful and faithful guidelines have a different set of materials and definitions, some entries in the JSON only contain one pack too. However, I've merged entries that are duplicated so you don't need an entirely different set of keywords.

The JSON is easily expandable if new entries are added in the future, and uses a pretty intuitive format for storing each item.

(I've already tested everything and it should be good to go)