### PR TITLE
Full instapass rewrite and overhaul

### DIFF
--- a/events/ready.js
+++ b/events/ready.js
@@ -29,7 +29,6 @@ const submissionProcess = new cron.CronJob('0 0 * * *', async () => {
       client,
       pack.channels.submit,
       pack.channels.council,
-      pack.channels.results,
       pack.vote_time
     )
 

--- a/functions/textures/admission/downloadResults.js
+++ b/functions/textures/admission/downloadResults.js
@@ -127,11 +127,12 @@ async function downloadResults(client, channelInID, instapass=false) {
 		})
 	}
 
+	let result = await contributionsCollection.addBulk(allContribution)
+
 	if (instapass) {
 		await pushTextures(`Instapassed texture from ${date()}`)
 	}
 
-	let result = await contributionsCollection.addBulk(allContribution)
 	if (process.DEBUG) console.log('ADDED CONTRIBUTIONS: ' + result.join(' '))
 }
 

--- a/functions/textures/admission/downloadResults.js
+++ b/functions/textures/admission/downloadResults.js
@@ -74,15 +74,20 @@ async function downloadResults(client, channelInID, instapass=false) {
 	}
 
 	// for each texture:
-	let allContribution = new Array()
+	let allContribution = new Array();
+	let instapassName; // there's probably a better way to get the texture name for instapassed embeds but oh well
+
 	for (let i = 0; textures[i]; i++) {
 		let textureID = textures[i].id
 		let textureURL = textures[i].url
 		let textureDate = textures[i].date
 		let textureAuthors = textures[i].authors
 
-		let texture = await texturesCollection.get(textureID)
-		let uses = await texture.uses()
+		let texture = await texturesCollection.get(textureID);
+
+		if (instapass) instapassName = texture.name;
+
+		let uses = await texture.uses();
 
 		let allPaths = new Array()
 		// get all paths of the texture
@@ -130,7 +135,7 @@ async function downloadResults(client, channelInID, instapass=false) {
 	let result = await contributionsCollection.addBulk(allContribution)
 
 	if (instapass) {
-		await pushTextures(`Instapassed texture from ${date()}`)
+		await pushTextures(`Instapassed ${instapassName} from ${date()}`)
 	}
 
 	if (process.DEBUG) console.log('ADDED CONTRIBUTIONS: ' + result.join(' '))

--- a/functions/textures/admission/downloadResults.js
+++ b/functions/textures/admission/downloadResults.js
@@ -57,10 +57,13 @@ async function downloadResults(client, channelInID, instapass=false) {
 		})
 
 	} else {
-		// returns the first one found since it will always be the most recent one getting pushed
-		const message = messages.find(message => {
-			message.embeds[0].fields[1].value.includes(settings.emojis.instapass)
-		})
+		let message;
+		for (let msg of messages) {
+			if (msg.embeds[0].fields[1].value.includes(settings.emojis.instapass)) {
+				message = msg;
+				break;
+			}
+		}
 
 		textures = {
 			url: message.embeds[0].image.url,

--- a/functions/textures/admission/downloadResults.js
+++ b/functions/textures/admission/downloadResults.js
@@ -65,12 +65,12 @@ async function downloadResults(client, channelInID, instapass=false) {
 			}
 		}
 
-		textures = {
+		textures = [{
 			url: message.embeds[0].image.url,
 			authors: message.embeds[0].fields[0].value.split('\n').map(auth => auth.replace('<@!', '').replace('>', '')),
 			date: message.createdTimestamp,
 			id: message.embeds[0].title.split(' ').filter(el => el.charAt(0) === '[' && el.charAt(1) === '#' && el.slice(-1) == "]").map(el => el.slice(2, el.length - 1))[0]
-		}
+		}];
 	}
 
 	// for each texture:
@@ -127,12 +127,12 @@ async function downloadResults(client, channelInID, instapass=false) {
 		})
 	}
 
+	if (instapass) {
+		await pushTextures(`Instapassed texture from ${date()}`)
+	}
+
 	let result = await contributionsCollection.addBulk(allContribution)
 	if (process.DEBUG) console.log('ADDED CONTRIBUTIONS: ' + result.join(' '))
-
-	if (instapass) {
-		pushTextures(`Instapassed texture from ${date()}`)
-	}
 }
 
 exports.downloadResults = downloadResults

--- a/functions/textures/admission/pushTextures.js
+++ b/functions/textures/admission/pushTextures.js
@@ -13,7 +13,9 @@ const settings = require('../../../resources/settings.json')
  * @author Juknum
  * @param {String} COMMIT_MESSAGE
  */
-async function pushTextures(COMMIT_MESSAGE = `Autopush passed textures from ${date()}`, ORGANIZATION='Faithful-Resource-Pack') {
+async function pushTextures(COMMIT_MESSAGE = `Autopush passed textures from ${date()}`) {
+	// TODO: make organization dynamic per-pack
+	const ORGANIZATION = 'Faithful-Resource-Pack'
 
 	const REPO_JAVA = Object.values(settings.repositories.repo_name.java);
 	const REPO_BEDROCK = Object.values(settings.repositories.repo_name.bedrock);

--- a/functions/textures/admission/pushTextures.js
+++ b/functions/textures/admission/pushTextures.js
@@ -13,7 +13,7 @@ const settings = require('../../../resources/settings.json')
  * @author Juknum
  * @param {String} COMMIT_MESSAGE
  */
-async function pushTextures(COMMIT_MESSAGE = `Autopush passed textures from ${date()}`) {
+async function pushTextures(COMMIT_MESSAGE = `Autopush passed textures from ${date()}`, ORGANIZATION='Faithful-Resource-Pack') {
 
 	const REPO_JAVA = Object.values(settings.repositories.repo_name.java);
 	const REPO_BEDROCK = Object.values(settings.repositories.repo_name.bedrock);
@@ -26,7 +26,7 @@ async function pushTextures(COMMIT_MESSAGE = `Autopush passed textures from ${da
 
 			if (checkFolder(`./texturesPush/${REPO_JAVA[i]}/${BRANCHES_JAVA[j]}/assets`)) {
 				try {
-					await pushToGitHub('Faithful-Resource-Pack', REPO_JAVA[i], `${BRANCHES_JAVA[j]}`, COMMIT_MESSAGE, `./texturesPush/${REPO_JAVA[i]}/${BRANCHES_JAVA[j]}/`)
+					await pushToGitHub(ORGANIZATION, REPO_JAVA[i], `${BRANCHES_JAVA[j]}`, COMMIT_MESSAGE, `./texturesPush/${REPO_JAVA[i]}/${BRANCHES_JAVA[j]}/`)
 				} catch(e) {
 					// branch doesn't exist, octokit causes an error
 				}
@@ -41,7 +41,7 @@ async function pushTextures(COMMIT_MESSAGE = `Autopush passed textures from ${da
 		for (let j = 0; BRANCHES_BEDROCK[j]; j++) {
 
 			if (checkFolder(`./texturesPush/${REPO_BEDROCK[i]}/${BRANCHES_BEDROCK[j]}/textures`)) {
-				await pushToGitHub('Faithful-Resource-Pack', REPO_BEDROCK[i], `${BRANCHES_BEDROCK[j]}`, COMMIT_MESSAGE, `./texturesPush/${REPO_BEDROCK[i]}/${BRANCHES_BEDROCK[j]}/`)
+				await pushToGitHub(ORGANIZATION, REPO_BEDROCK[i], `${BRANCHES_BEDROCK[j]}`, COMMIT_MESSAGE, `./texturesPush/${REPO_BEDROCK[i]}/${BRANCHES_BEDROCK[j]}/`)
 				fs.rmdirSync(`./texturesPush/${REPO_BEDROCK[i]}/${BRANCHES_BEDROCK[j]}/textures/`, { recursive: true })
 
 				if (DEBUG) console.log(`PUSHED TO GITHUB: Faithful-Java-32x (${BRANCHES_BEDROCK[j]})`)

--- a/functions/textures/admission/pushTextures.js
+++ b/functions/textures/admission/pushTextures.js
@@ -34,7 +34,6 @@ async function pushTextures(COMMIT_MESSAGE = `Autopush passed textures from ${da
 
 				if (DEBUG) console.log(`PUSHED TO GITHUB: Faithful-Java-32x (${BRANCHES_JAVA[j]})`)
 			}
-
 		}
 	}
 

--- a/functions/textures/submission/changeStatus.js
+++ b/functions/textures/submission/changeStatus.js
@@ -1,0 +1,15 @@
+/*
+ * Change status of embed
+ * @author Evorp
+ * @param {Discord.message} message
+ * @param {String} string
+ * @param {String} color
+ */
+async function changeStatus(message, string, color=null) {
+    let embed = message.embeds[0]
+    embed.fields[1].value = string
+    embed.color = color ?? embed.color;
+    await message.edit({ embeds: [embed] })
+}
+
+exports.changeStatus = changeStatus

--- a/functions/textures/submission/councilSubmission.js
+++ b/functions/textures/submission/councilSubmission.js
@@ -1,6 +1,7 @@
 const settings = require('../../../resources/settings.json')
 
 const { getMessages } = require('../../../helpers/getMessages')
+const { changeStatus } = require('./changeStatus')
 
 /**
  * @author Juknum
@@ -54,7 +55,7 @@ async function councilSubmission(client, channelFromID, channelResultsID, delay)
         for (const emojiID of [settings.emojis.see_more]) await sentMessage.react(client.emojis.cache.get(emojiID))
       })
 
-    editEmbed(message.message, `<:upvote:${settings.emojis.upvote}> Sent to results!`)
+    changeStatus(message.message, `<:upvote:${settings.emojis.upvote}> Sent to results!`)
   })
 
   // send downvoted messages to #results (denied)
@@ -68,18 +69,8 @@ async function councilSubmission(client, channelFromID, channelResultsID, delay)
         for (const emojiID of [settings.emojis.see_more]) await sentMessage.react(client.emojis.cache.get(emojiID))
       })
 
-    editEmbed(message.message, `<:upvote:${settings.emojis.upvote}> Sent to results!`)
+    changeStatus(message.message, `<:upvote:${settings.emojis.upvote}> Sent to results!`)
   })
-}
-
-async function editEmbed(message, string) {
-  let embed = message.embeds[0]
-  embed.fields[1].value = string
-
-  // fix the weird bug that also apply changes to the old embed (wtf)
-  embed.setColor(settings.colors.council)
-
-  await message.edit({ embeds: [embed] })
 }
 
 exports.councilSubmission = councilSubmission

--- a/functions/textures/submission/editSubmission.js
+++ b/functions/textures/submission/editSubmission.js
@@ -131,7 +131,6 @@ async function instapass(client, message) {
     return;
   }
 
-
   await channelOut.send({
     embeds:
       [message.embeds[0]

--- a/functions/textures/submission/editSubmission.js
+++ b/functions/textures/submission/editSubmission.js
@@ -87,8 +87,7 @@ async function editSubmission(client, reaction, user) {
             removeReact(message, [settings.emojis.upvote, settings.emojis.downvote])
             changeStatus(message, `<:instapass:${settings.emojis.instapass}> Instapassed`)
             instapass(client, message)
-          }
-          if (REACTION.emoji.id === settings.emojis.invalid) {
+          } else if (REACTION.emoji.id === settings.emojis.invalid) {
             removeReact(message, [settings.emojis.upvote, settings.emojis.downvote])
             changeStatus(message, `<:invalid:${settings.emojis.invalid}> Invalid`)
           }

--- a/functions/textures/submission/editSubmission.js
+++ b/functions/textures/submission/editSubmission.js
@@ -124,12 +124,13 @@ async function instapass(client, message) {
     }
   }
 
+  const channelOut = await client.channels.fetch(channelOutID);
+
   if (!channelOut) {
     warnUser(message, "Result channel was not able to be fetched.");
     return;
   }
 
-  const channelOut = await client.channels.fetch(channelOutID);
 
   channelOut.send({
     embeds:

--- a/functions/textures/submission/editSubmission.js
+++ b/functions/textures/submission/editSubmission.js
@@ -22,7 +22,7 @@ nocache(CANVAS_FUNCTION_PATH)
 async function editSubmission(client, reaction, user) {
   const message = await reaction.message.fetch()
   const member = await message.guild.members.cache.get(user.id)
-  if (member.bot === true) return
+  if (member.bot) return
   if (message.embeds.length == 0 || message.embeds[0].fields.length == 0) return
 
   const authorID = await message.embeds[0].fields[0].value.split('\n').map(el => el.replace('<@', '').replace('!', '').replace('>', ''))[0]
@@ -134,7 +134,7 @@ async function instapass(client, message) {
   await channelOut.send({
     embeds:
       [message.embeds[0]
-        .setColor(settings.colors.green)
+        .setColor(settings.colors.yellow)
         .setDescription(`[Original Post](${message.url})\n${message.embeds[0].description ? message.embeds[0].description : ''}`)
       ]
   })

--- a/functions/textures/submission/editSubmission.js
+++ b/functions/textures/submission/editSubmission.js
@@ -131,7 +131,7 @@ async function instapass(client, message) {
   }
 
 
-  channelOut.send({
+  await channelOut.send({
     embeds:
       [message.embeds[0]
         .setColor(settings.colors.green)
@@ -142,8 +142,8 @@ async function instapass(client, message) {
       for (const emojiID of [settings.emojis.see_more]) await sentMessage.react(client.emojis.cache.get(emojiID))
     })
 
-  editEmbed(message);
-  downloadResults(client, channelOutID, true);
+  await editEmbed(message);
+  await downloadResults(client, channelOutID, true);
 }
 
 async function editEmbed(message) {

--- a/functions/textures/submission/editSubmission.js
+++ b/functions/textures/submission/editSubmission.js
@@ -7,6 +7,7 @@ const { tile } = require('../tile')
 const { warnUser } = require('../../../helpers/warnUser')
 const compareFunction = require('../compare')
 const { downloadResults } = require("../admission/downloadResults")
+const { changeStatus } = require('./changeStatus')
 
 const CANVAS_FUNCTION_PATH = '../../../functions/textures/canvas'
 function nocache(module) { require('fs').watchFile(require('path').resolve(module), () => { delete require.cache[require.resolve(module)] }) }
@@ -85,11 +86,11 @@ async function editSubmission(client, reaction, user) {
         if (member.roles.cache.some(role => role.name.toLowerCase().includes("council") || role.name.toLowerCase().includes("admin"))) {
           if (REACTION.emoji.id === settings.emojis.instapass) {
             removeReact(message, [settings.emojis.upvote, settings.emojis.downvote])
-            changeStatus(message, `<:instapass:${settings.emojis.instapass}> Instapassed`)
+            changeStatus(message, `<:instapass:${settings.emojis.instapass}> Instapassed`, settings.colors.yellow)
             instapass(client, message)
           } else if (REACTION.emoji.id === settings.emojis.invalid) {
             removeReact(message, [settings.emojis.upvote, settings.emojis.downvote])
-            changeStatus(message, `<:invalid:${settings.emojis.invalid}> Invalid`)
+            changeStatus(message, `<:invalid:${settings.emojis.invalid}> Invalid`, settings.colors.black)
           }
         }
 
@@ -142,31 +143,7 @@ async function instapass(client, message) {
       for (const emojiID of [settings.emojis.see_more]) await sentMessage.react(client.emojis.cache.get(emojiID))
     })
 
-  await editEmbed(message);
   await downloadResults(client, channelOutID, true);
-}
-
-async function editEmbed(message) {
-  let embed = message.embeds[0]
-  // fix the weird bug that also apply changes to the old embed (wtf)
-  const submissionChannels = Object.values(settings.submission.packs).map(i => i.channels.submit);
-  const councilChannels = Object.values(settings.submission.packs).map(i => i.channels.council);
-
-  if (submissionChannels.includes(message.channel.id))
-    embed.setColor(settings.colors.blue)
-
-  else if (councilChannels.includes(message.channel.id))
-    embed.setColor(settings.colors.council)
-
-  if (embed.description !== null) embed.setDescription(message.embeds[0].description.replace(`[Original Post](${message.url})\n`, ''))
-
-  await message.edit({ embeds: [embed] })
-}
-
-async function changeStatus(message, string) {
-  let embed = message.embeds[0]
-  embed.fields[1].value = string
-  await message.edit({ embeds: [embed] })
 }
 
 async function removeReact(message, emojis) {

--- a/functions/textures/submission/editSubmission.js
+++ b/functions/textures/submission/editSubmission.js
@@ -38,7 +38,7 @@ async function editSubmission(client, reaction, user) {
       EMOJIS = EMOJIS.filter(emoji => emoji !== settings.emojis.instapass && emoji !== settings.emojis.invalid && emoji !== settings.emojis.delete)
 
     // if the message is in #council-vote remove delete reaction (avoid misclick)
-    const councilChannels = Object.values(settings.submission).map(i => i.channels.council);
+    const councilChannels = Object.values(settings.submission.packs).map(i => i.channels.council);
 
     if (councilChannels.includes(message.channel.id)) {
       EMOJIS = EMOJIS.filter(emoji => emoji !== settings.emojis.delete)
@@ -149,8 +149,8 @@ async function instapass(client, message) {
 async function editEmbed(message) {
   let embed = message.embeds[0]
   // fix the weird bug that also apply changes to the old embed (wtf)
-  const submissionChannels = Object.values(settings.submission).map(i => i.channels.submit);
-  const councilChannels = Object.values(settings.submission).map(i => i.channels.council);
+  const submissionChannels = Object.values(settings.submission.packs).map(i => i.channels.submit);
+  const councilChannels = Object.values(settings.submission.packs).map(i => i.channels.council);
 
   if (submissionChannels.includes(message.channel.id))
     embed.setColor(settings.colors.blue)

--- a/functions/textures/submission/retrieveSubmission.js
+++ b/functions/textures/submission/retrieveSubmission.js
@@ -1,6 +1,7 @@
 const settings = require('../../../resources/settings.json')
 
 const { getMessages } = require('../../../helpers/getMessages')
+const { changeStatus } = require('./changeStatus')
 
 /**
  * @author Juknum
@@ -54,7 +55,7 @@ async function retrieveSubmission(client, channelFromID, channelOutID, delay) {
 
 	// change status message
 	messagesDownvoted.forEach(message => {
-		editEmbed(message.message, `<:downvote:${settings.emojis.downvote}> Not enough upvotes!`)
+		changeStatus(message.message, `<:downvote:${settings.emojis.downvote}> Not enough upvotes!`, settings.colors.red)
 	})
 
 	// send message to the output channel & change status
@@ -71,19 +72,6 @@ async function retrieveSubmission(client, channelFromID, channelOutID, delay) {
 				for (const emojiID of EMOJIS) await sentMessage.react(client.emojis.cache.get(emojiID))
 			})
 
-		editEmbed(message.message, `<:upvote:${settings.emojis.upvote}> Sent to Council!`)
+		changeStatus(message.message, `<:upvote:${settings.emojis.upvote}> Sent to Council!`, settings.colors.green)
 	})
 }
-
-async function editEmbed(message, string) {
-	let embed = message.embeds[0]
-	embed.fields[1].value = string
-
-	// fix the weird bug that also apply changes to the old embed (wtf)
-	embed.setColor(settings.colors.blue)
-	if (embed.description !== null) embed.setDescription(message.embeds[0].description.replace(`[Original Post](${message.url})\n`, ''))
-
-	await message.edit({ embeds: [embed] })
-}
-
-exports.retrieveSubmission = retrieveSubmission

--- a/functions/textures/submission/retrieveSubmission.js
+++ b/functions/textures/submission/retrieveSubmission.js
@@ -7,26 +7,14 @@ const { getMessages } = require('../../../helpers/getMessages')
  * @param {DiscordClient} client
  * @param {String} channelFromID text-channel from where submission are retrieved
  * @param {String} channelOutID text-channel where submission are sent
- * @param {String} channelInstapassID text-channel where instapassed textures are sent
  * @param {Integer} delay delay in day from today
  */
-async function retrieveSubmission(client, channelFromID, channelOutID, channelInstapassID, delay) {
+async function retrieveSubmission(client, channelFromID, channelOutID, delay) {
 	let messages = await getMessages(client, channelFromID)
 	let channelOut = client.channels.cache.get(channelOutID)
-	let channelInstapass = client.channels.cache.get(channelInstapassID)
 
 	let delayedDate = new Date();
 	delayedDate.setDate(delayedDate.getDate() - delay);
-
-	let instapassedDate = new Date(); // no delay
-
-	let messagesInstapassed = messages.filter(message => {
-		let messageDate = new Date(message.createdTimestamp);
-		return messageDate.getDate() == instapassedDate.getDate() && messageDate.getMonth() == instapassedDate.getMonth();
-	}) // only get instapassed textures
-		.filter(message => message.embeds.length > 0)
-		.filter(message => message.embeds[0].fields[1] !== undefined && (message.embeds[0].fields[1].value.includes(settings.emojis.instapass)))
-
 
 	// filter message in the right timezone
 	messages = messages.filter(message => {
@@ -67,17 +55,6 @@ async function retrieveSubmission(client, channelFromID, channelOutID, channelIn
 	// change status message
 	messagesDownvoted.forEach(message => {
 		editEmbed(message.message, `<:downvote:${settings.emojis.downvote}> Not enough upvotes!`)
-	})
-
-	messagesInstapassed.forEach(message => {
-		let embed = message.embeds[0];
-		embed.setColor(settings.colors.green);
-		embed.fields[1].value = `<:instapass:${settings.emojis.instapass}> Instapassed`;
-
-		channelInstapass.send({ embeds: [embed] })
-			.then(async sentMessage => {
-				for (const emojiID of [settings.emojis.see_more]) await sentMessage.react(client.emojis.cache.get(emojiID))
-			})
 	})
 
 	// send message to the output channel & change status


### PR DESCRIPTION
While I made #229 barely a day ago, I've come across a far better solution to this problem. In addition, the fix I made wasn't actually well suited to pack manager needs, since you'd be having to wait up to 23 hours for a texture to push — not exactly an "instant pass".

In #229, I discuss the problems with pushing textures asynchronously in that pull request. These criticisms still hold up, but I never really considered the fact that I could just create an instapass flag variable that one could pass into submission-related functions. This instapass flag would be able to easily control which parts of the function needed to be edited to allow textures to actually push instantly, instead of relying on the one central push per day which the entire bot is based around.

In a sense, this almost reverts #229 since instapassed textures now get pushed to results instantly again, but instead of failing to be pushed synchronously, it now pushes asynchronously, as soon as possible.

ACTUAL CHANGES:
- Revert pretty much all the changes made in #229 
- Add instapass flag variable to `downloadResults()`
   - If instapass flag variable is true, the bot now runs `pushTextures()` directly from `downloadResults()` instead of waiting on the cron job as was done prior.
   - The bot only fetches the most recent instapassed texture, since all prior ones should have been pushed since then, which allows for textures instapassed days prior to still get pushed instantly.
- Make GitHub organization names not hardcoded, for potential classic faithful support in the near future.